### PR TITLE
Update DEPS

### DIFF
--- a/Build_Kernel.sh
+++ b/Build_Kernel.sh
@@ -91,7 +91,7 @@ cd "$WORKSPACE" || error "无法进入工作目录"
 
 # 检查并安装依赖
 info "检查并安装依赖..."
-DEPS=(python3 git curl ccache flex bison libssl-dev libelf-dev bc make)
+DEPS=(python3 git curl ccache flex bison libssl-dev libelf-dev bc make zip)
 MISSING_DEPS=()
 
 for pkg in "${DEPS[@]}"; do


### PR DESCRIPTION
经测试，Ubuntu 2004/2204 WSL 均未预装make，运行脚本时出现报错
![image](https://github.com/user-attachments/assets/bdc8f1ff-459b-44a4-a600-a14eb3970365)
